### PR TITLE
Switch downloading from http to rsync.

### DIFF
--- a/3rdparty/requirements.txt
+++ b/3rdparty/requirements.txt
@@ -1,3 +1,2 @@
 click>=3.3,<3.4
 pytest>=2.5
-requests>=2.3.0,<2.4

--- a/src/python/gitshed/BUILD
+++ b/src/python/gitshed/BUILD
@@ -2,7 +2,6 @@ python_library(name='lib',
                sources=globs('*.py') - ['main.py'],
                dependencies=[
                  '3rdparty:click',
-                 '3rdparty:requests',
                ]
 )
 

--- a/src/python/gitshed/content_store.py
+++ b/src/python/gitshed/content_store.py
@@ -160,6 +160,8 @@ class ContentStore(object):
   def has(self, key):
     """Checks for the existence of content in this content store.
 
+    Used only for testing/setup verification.
+
     :param key: Check for content under this key.
     """
     return self.raw_has(self.content_store_path_from_key(key))

--- a/src/python/gitshed/gitshed.py
+++ b/src/python/gitshed/gitshed.py
@@ -79,8 +79,7 @@ class GitShed(object):
         timeout_secs = rcfg.get('timeout_secs', 5)
       except KeyError as e:
         raise MissingConfigKeyError(e)
-      content_store = RSyncedRemoteContentStore(host, root_path, root_url,
-                                                timeout_secs,
+      content_store = RSyncedRemoteContentStore(host, root_path,
                                                 concurrency.get('get'),
                                                 concurrency.get('put'))
     elif 'local' in content_store_cfg:

--- a/src/python/gitshed/remote_content_store.py
+++ b/src/python/gitshed/remote_content_store.py
@@ -4,71 +4,46 @@ from __future__ import (nested_scopes, generators, division, absolute_import, wi
                         print_function, unicode_literals)
 
 import os
-import urlparse
-
-import requests
 
 from gitshed.content_store import ContentStore
 from gitshed.error import GitShedError
-from gitshed.util import run_cmd_str
+from gitshed.util import run_cmd_str, temporary_dir
 
 
-class RemoteContentStore(ContentStore):
-  """A content_store on a remote server.
-
-  Reads using HTTP(S) GET/HEAD.  Subclasses must implement writes.
-  """
-  READ_SIZE_BYTES = 4 * 1024 * 1024
-
-  def __init__(self, root_url, timeout_secs=None, get_concurrency=None, put_concurrency=None):
-    super(RemoteContentStore, self).__init__(get_concurrency, put_concurrency)
-    self._root_url = root_url
-    self._timeout_secs = timeout_secs or 10
-    self._session = requests.Session()
-
-  def raw_get(self, content_store_path, target_path_tmp):
-    url = self._get_full_content_store_url(content_store_path)
-    response = self._session.get(url, timeout=self._timeout_secs, stream=True)
-    if not self._is_ok(url, response):
-      raise GitShedError('Resource does not exist: {0}'.format(url))
-    with open(target_path_tmp, 'w') as outfile:
-      for chunk in response.iter_content(self.READ_SIZE_BYTES):
-        outfile.write(chunk)
-
-  def raw_has(self, path):
-    url = self._get_full_content_store_url(path)
-    response = self._session.head(url, timeout=self._timeout_secs)
-    return self._is_ok(url, response)
-
-  def _get_full_content_store_url(self, content_store_path):
-    return urlparse.urljoin(self._root_url, content_store_path)
-
-  def _is_ok(self, url, response):
-    """Does the response represent a successful HTTP round trip?"""
-    if 200 <= response.status_code < 300:  # Allow all 2XX responses. E.g., HEAD can return 204.
-      return True
-    elif response.status_code == 404:
-      return False
-    else:
-      raise GitShedError('Error accessing {0}: {1} {2}'.format(
-        url, response.status_code, response.reason))
-
-
-class RSyncedRemoteContentStore(RemoteContentStore):
+class RSyncedRemoteContentStore(ContentStore):
   """A remote content_store that writes using rsync."""
-  def __init__(self, host, root_path, root_url, timeout_secs=None,
-               get_concurrency=None, put_concurrency=None):
-    super(RSyncedRemoteContentStore, self).__init__(root_url, timeout_secs,
-                                                    get_concurrency, put_concurrency)
+  def __init__(self, host, root_path, get_concurrency=None, put_concurrency=None):
+    super(RSyncedRemoteContentStore, self).__init__(get_concurrency, put_concurrency)
     self._host = host
     self._remote_root_path = root_path
+
+  def raw_get(self, content_store_path, target_path_tmp):
+    cmd_str, retcode, stdout, stderr = self._try_raw_get(content_store_path, target_path_tmp)
+    if retcode:
+      raise GitShedError(
+        'Failed to rsync {0} from {1}:{2}.\ncommand: {3}\nstdout: {4}\nstderr: {5}'.format(
+          target_path_tmp, self._host, content_store_path, cmd_str, stdout, stderr))
+
+  def raw_has(self, path):
+    # We implement by actually downloading the file to a dummy location.  This isn't particularly
+    # efficient, but this is only used in tests/client checks anyway.
+    with temporary_dir() as tmpdir:
+      dummy = os.path.join(tmpdir, 'dummy')
+      _, retcode, _, _ = self._try_raw_get(path, dummy)
+      return retcode == 0
+
+  def _try_raw_get(self, content_store_path, target_path_tmp):
+    remote_path = os.path.join(self._remote_root_path, content_store_path)
+    cmd_str = 'rsync -acvz {0}:{1} "{2}"'.format(self._host, remote_path, target_path_tmp)
+    retcode, stdout, stderr = run_cmd_str(cmd_str)
+    return cmd_str, retcode, stdout, stderr
 
   def raw_put(self, src_path, content_store_path):
     # Note that rsync does an atomic rename at the end of a write, so we don't need
     # to emulate that functionality ourselves.
     remote_path = os.path.join(self._remote_root_path, content_store_path)
     remote_dir = os.path.dirname(remote_path)
-    cmd_str = 'rsync -cv --rsync-path="sudo mkdir -p {0} && sudo rsync" "{1}" {2}:{3}'.format(
+    cmd_str = 'rsync -acvz --rsync-path="sudo mkdir -p {0} && sudo rsync" "{1}" {2}:{3}'.format(
       remote_dir, src_path, self._host, remote_path)
     retcode, stdout, stderr = run_cmd_str(cmd_str)
     if retcode:

--- a/src/python/gitshed/util.py
+++ b/src/python/gitshed/util.py
@@ -40,14 +40,15 @@ def safe_rmtree(path):
 
 
 @contextmanager
-def temporary_dir(suffix='', prefix='gitshed.'):
+def temporary_dir(suffix='', prefix='gitshed.', ignore_errors=False, cleanup=True):
   """A context yielding an empty temporary directory.
 
   The directory is guaranteed to exist within the context and to be cleaned up on context exit.
   """
   ret = tempfile.mkdtemp(suffix=suffix, prefix=prefix)
   yield ret
-  shutil.rmtree(ret)
+  if cleanup:
+    shutil.rmtree(ret, ignore_errors=ignore_errors)
 
 
 def run_cmd_str(cmd_str):

--- a/test/python/gitshed_test/helpers.py
+++ b/test/python/gitshed_test/helpers.py
@@ -12,9 +12,10 @@ from gitshed.util import run_cmd_str, safe_makedirs, temporary_dir
 
 
 @contextmanager
-def temporary_test_dir(suffix=''):
+def temporary_test_dir(suffix='', cleanup=True, ignore_errors=False):
   """A context yielding a temporary directory for testing."""
-  with temporary_dir(suffix=suffix, prefix='gitshed_test.') as tmpdir:
+  with temporary_dir(suffix=suffix, prefix='gitshed_test.', cleanup=cleanup,
+                     ignore_errors=ignore_errors) as tmpdir:
     yield tmpdir
 
 


### PR DESCRIPTION
- Allows us to preserve file permissions.
- Is more robust in general.
