### PR TITLE
Add an "unmanage" git shed command.

### DIFF
--- a/src/python/gitshed/main.py
+++ b/src/python/gitshed/main.py
@@ -104,6 +104,15 @@ def manage(paths):
 
 @click.command()
 @path_glob_args
+def unmanage(paths):
+  if paths:
+    with exception_handling():
+      gb = gitshed_instance()
+      gb.unmanage(paths)
+
+
+@click.command()
+@path_glob_args
 def sync(paths):
   with exception_handling():
     gb = gitshed_instance()
@@ -134,6 +143,7 @@ gitshed.add_command(status)
 gitshed.add_command(synced)
 gitshed.add_command(unsynced)
 gitshed.add_command(manage)
+gitshed.add_command(unmanage)
 gitshed.add_command(sync)
 gitshed.add_command(resync)
 gitshed.add_command(setup)

--- a/src/python/gitshed/repo.py
+++ b/src/python/gitshed/repo.py
@@ -44,7 +44,7 @@ class GitRepo(object):
     :rtype: str
     :raises GitShedError: If the resolved path is not under this root.
     """
-    abspath = os.path.realpath(os.path.normpath(os.path.join(self._root, os.path.expanduser(path))))
+    abspath = os.path.normpath(os.path.join(self._root, os.path.expanduser(path)))
     if not abspath.startswith(self._root):
       raise GitShedError('{0} is not under git repo root {1}'.format(abspath, self._root))
     return abspath

--- a/src/python/gitshed/util.py
+++ b/src/python/gitshed/util.py
@@ -44,6 +44,10 @@ def make_read_only(path):
   mode = os.stat(path)[stat.ST_MODE]
   os.chmod(path, mode & ~0222)
 
+def make_user_writeable(path):
+  mode = os.stat(path)[stat.ST_MODE]
+  os.chmod(path, mode | 0200)
+
 
 @contextmanager
 def temporary_dir(suffix='', prefix='gitshed.', ignore_errors=False, cleanup=True):


### PR DESCRIPTION
This basically undoes a "manage" command: It removes the symlink and
restores the original file.

This is useful if the file needs to be edited and then re-uploaded.
