### PR TITLE
Upload multiple files in a single rsync command.

### DIFF
--- a/src/python/gitshed/gitshed.py
+++ b/src/python/gitshed/gitshed.py
@@ -217,7 +217,7 @@ class GitShed(object):
         relpaths.append(relpath)
 
     # Upload everything to the content store.
-    keys = self._content_store.multi_put(relpaths)
+    keys = self._content_store.put(relpaths)
 
     # Move the files into the shed.
     for key, relpath in zip(keys, relpaths):

--- a/src/python/gitshed/local_content_store.py
+++ b/src/python/gitshed/local_content_store.py
@@ -24,8 +24,10 @@ class LocalContentStore(ContentStore):
       target_path_tmp = os.path.join(target_dir_tmp, os.path.basename(path))
       shutil.copy(self._get_full_content_store_path(path), target_path_tmp)
 
-  def raw_put(self, src_path, content_store_path):
-    self._safe_copy(src_path,  self._get_full_content_store_path(content_store_path))
+  def raw_put(self, src_paths, content_store_dir):
+    for src_path in src_paths:
+      content_store_path = '{0}/{1}'.format(content_store_dir, os.path.basename(src_path))
+      self._safe_copy(src_path,  self._get_full_content_store_path(content_store_path))
 
   def raw_has(self, content_store_path):
     return os.path.isfile(self._get_full_content_store_path(content_store_path))

--- a/src/python/gitshed/remote_content_store.py
+++ b/src/python/gitshed/remote_content_store.py
@@ -37,17 +37,17 @@ class RSyncedRemoteContentStore(ContentStore):
     retcode, stdout, stderr = run_cmd_str(cmd_str)
     return cmd_str, retcode, stdout, stderr
 
-  def raw_put(self, src_path, content_store_path):
+  def raw_put(self, src_paths, content_store_dir):
     # Note that rsync does an atomic rename at the end of a write, so we don't need
     # to emulate that functionality ourselves.
-    remote_path = os.path.join(self._remote_root_path, content_store_path)
-    remote_dir = os.path.dirname(remote_path)
-    cmd_str = """rsync -acvz --rsync-path="sudo mkdir -p {0} && sudo rsync" '{1}' {2}:{3}""".format(
-      remote_dir, src_path, self._host, remote_path)
+    remote_dir = os.path.join(self._remote_root_path, content_store_dir)
+    src_paths_str = ' '.join("'{0}'".format(src_path) for src_path in src_paths)
+    cmd_str = """rsync -acvz --rsync-path="sudo mkdir -p {0} && sudo rsync" {1} {2}:{3}""".format(
+      remote_dir, src_paths_str, self._host, remote_dir)
     retcode, stdout, stderr = run_cmd_str(cmd_str)
     if retcode:
       raise GitShedError('Failed to rsync {0} to {1}:{2}.\ncommand: {3}\nstdout: {4}\nstderr: {5}'.
-                         format(src_path, self._host, content_store_path, cmd_str, stdout, stderr))
+                         format(src_paths_str, self._host, content_store_dir, cmd_str, stdout, stderr))
 
 
   @staticmethod

--- a/test/python/gitshed_test/test_content_store.py
+++ b/test/python/gitshed_test/test_content_store.py
@@ -96,7 +96,7 @@ class ContentStoreTest(unittest.TestCase):
       key = ContentStore.sha(fullpath)
 
       self.assertFalse(content_store.has(key))
-      content_store.put(fullpath)
+      content_store.put([fullpath])
       self.assertTrue(content_store.has(key))
 
       self.assertTrue(os.path.exists(fullpath))
@@ -147,10 +147,9 @@ class ContentStoreTest(unittest.TestCase):
         fullpath2mode[fullpath] = current_mode
         key2fullpaths[key].append(fullpath)
 
+      content_store.put(fullpath2key.keys())
+
       for fullpath, key in fullpath2key.items():
-        # TODO: Switch to 'multi_put' here after that's re-implemented to correctly handle
-        # multiple files with the same content.
-        content_store.put(fullpath)
         self.assertTrue(content_store.has(key))
         self.assertTrue(os.path.exists(fullpath))
         os.remove(fullpath)


### PR DESCRIPTION
As with gets, this makes uploads 3x faster at least.

multi_put() is now renamed simply put(), and the old single-path put() is no more.

All tests pass (including the rsync ones), plus I've tried this out on 1000 files in our real repo.
