### PR TITLE
Handle the case of files with the same content but different permissions...

### DIFF
--- a/src/python/gitshed/util.py
+++ b/src/python/gitshed/util.py
@@ -8,7 +8,6 @@ import errno
 import os
 import shlex
 import shutil
-import stat
 import subprocess
 import tempfile
 
@@ -40,12 +39,15 @@ def safe_rmtree(path):
   shutil.rmtree(path, True)
 
 
+def make_mode_read_only(mode):
+  return mode & ~0222
+
 def make_read_only(path):
-  mode = os.stat(path)[stat.ST_MODE]
-  os.chmod(path, mode & ~0222)
+  mode = os.stat(path).st_mode
+  os.chmod(path, make_mode_read_only(mode))
 
 def make_user_writeable(path):
-  mode = os.stat(path)[stat.ST_MODE]
+  mode = os.stat(path).st_mode
   os.chmod(path, mode | 0200)
 
 


### PR DESCRIPTION
....

We do this by adding the octal mode string to the content store key.
It's pretty straightforward, but this did involve moving some classmethods
from GitShed to ContentStore, to keep all key-related methods in one place.

Also switched to a better way of getting a file's mode (.st_mode instead of
[stat.ST_MODE]. It turns out that the latter is just a legacy, and the former
is the cool way to access the mode from the stat struct.

Note that this change breaks existing gitshed files, as their keys are
now different! I plan to migrate our existing gitshedded repo by unmanaging
all files, then upgrading to the new gitshed, then re-managing, then
committing all of the above in a single commit.
